### PR TITLE
fix dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "vue",
     "google"
   ],
-  "dependencies": {
+  "devDependencies": {
     "babel-core": "^6.21.0",
     "babel-loader": "^6.2.10",
     "babel-preset-es2015": "^6.18.0",


### PR DESCRIPTION
well first, thx for this plugin :D 

Then, about the PR : 

all your build dependencies should be in devDependencies

otherwise they are polluting dependencies of people using your plugin

We couldn't use it for example because we are using webpack 3 and your webpack 2 dependency causes issues