### PR TITLE
No id provided

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -27,6 +27,10 @@ export const loadScript = function (id) {
     'gtm.start': new Date().getTime(),
   })
 
+  if (!id) {
+    return
+  }
+
   script.async = true;
   script.src   = `https://www.googletagmanager.com/gtm.js?id=${id}`
 


### PR DESCRIPTION
If you want to add trackings without defining a GTM id and check result only with checking dataLayer a tag manager script tag will be inserted without GTM id.