### PR TITLE
ignoredViews when load from a ignoredView

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ const initVueRouterGuard = function (Vue, { vueRouter, ignoredViews, trackOnNext
 
   vueRouter.afterEach(to => {
     // Ignore some routes
-    if (ignoredViews && ignoredViews.indexOf(to.name.toLowerCase()) !== -1) {
+    if (!to.name || (ignoredViews && ignoredViews.indexOf(to.name.toLowerCase()) !== -1)) {
       return
     }
 


### PR DESCRIPTION
When load a app from a ignoredView, the view are not ignored, because the to.name is null.