### PR TITLE
Add a way to access to the dataLayer

### DIFF
--- a/src/GtmPlugin.js
+++ b/src/GtmPlugin.js
@@ -70,4 +70,12 @@ export default class AnalyticsPlugin {
       })
     }
   }
+
+  get dataLayer() {
+    if (inBrowser && pluginConfig.enabled) {
+      return (window.dataLayer = window.dataLayer || []);
+    }
+
+    return false;
+  }
 }


### PR DESCRIPTION
I need a way to push custom variables in dataLayer, and i think it's something that needs to be done outside the plugin, i can use the directly the window object but i think it's more conviennent like this.