### PR TITLE
Load script config option 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Vue.use(VueGtm, {
   id: 'GTM-xxxxxxx', // Your GTM ID
   enabled: true, // defaults to true. Plugin can be disabled by setting this to false for Ex: enabled: !!GDPR_Cookie (optional)
   debug: true, // Whether or not display console logs debugs (optional)
+  loadScript: true, // Whether or not to load the GTM Script (Helpful if you are including GTM manually, but need the dataLayer functionality in your components) (optional) 
   vueRouter: router, // Pass the router instance to automatically sync with router (optional)
   ignoredViews: ['homepage'] // If router, you can exclude some routes name (case insensitive) (optional)
 });

--- a/src/GtmPlugin.js
+++ b/src/GtmPlugin.js
@@ -13,7 +13,7 @@ export default class AnalyticsPlugin {
   enable(val) {
     pluginConfig.enabled = val
 
-    if (inBrowser && !!val && !hasScript()) {
+    if (inBrowser && !!val && !hasScript() && pluginConfig.loadScript) {
       loadScript(pluginConfig.id)
     }
   }

--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,6 @@
 export default {
   enabled: true,
   debug: false,
-  trackOnNextTick: false
+  trackOnNextTick: false,
+  loadScript: true,
 }


### PR DESCRIPTION
Helpful if you are including GTM manually, but need the dataLayer functionality in your components. Therefore this will prevent `vue-gtm` from 404'ing if you don't include an id.