### PR TITLE
Add compatibility for defer option for old browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ app.use(createGtm({
     gtm_cookies_win:'x'
   },
   defer: false, // Script can be set to `defer` to speed up page load at the cost of less accurate results (in case visitor leaves before script is loaded, which is unlikely but possible). Defaults to false, so the script is loaded `async` by default
-  compability: false, // Will add `async` and `defer` to the script tag to not block requests for old browsers that do not support `async`
+  compatibility: false, // Will add `async` and `defer` to the script tag to not block requests for old browsers that do not support `async`
   enabled: true, // defaults to true. Plugin can be disabled by setting this to false for Ex: enabled: !!GDPR_Cookie (optional)
   debug: true, // Whether or not display console logs debugs (optional)
   loadScript: true, // Whether or not to load the GTM Script (Helpful if you are including GTM manually, but need the dataLayer functionality in your components) (optional)

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ app.use(createGtm({
     gtm_preview:'env-4',
     gtm_cookies_win:'x'
   },
-  defer: false, // defaults to false. Script can be set to `defer` to increase page-load-time at the cost of less accurate results (in case visitor leaves before script is loaded, which is unlikely but possible)
+  defer: false, // Script can be set to `defer` to speed up page load at the cost of less accurate results (in case visitor leaves before script is loaded, which is unlikely but possible). Defaults to false, so the script is loaded `async` by default
+  compability: false, // Will add `async` and `defer` to the script tag to not block requests for old browsers that do not support `async`
   enabled: true, // defaults to true. Plugin can be disabled by setting this to false for Ex: enabled: !!GDPR_Cookie (optional)
   debug: true, // Whether or not display console logs debugs (optional)
   loadScript: true, // Whether or not to load the GTM Script (Helpful if you are including GTM manually, but need the dataLayer functionality in your components) (optional)

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,11 +12,17 @@ export interface VueGtmUseOptions {
     gtm_cookies_win: string;
   };
   /**
-   * Script can be set to `defer` to increase page-load-time at the cost of less accurate results (in case visitor leaves before script is loaded, which is unlikely but possible)
+   * Script can be set to `defer` to speed up page load at the cost of less accurate results (in case visitor leaves before script is loaded, which is unlikely but possible). Defaults to false, so the script is loaded `async` by default
    *
    * @default false
    */
   defer?: boolean;
+  /**
+   * Will add `async` and `defer` to the script tag to not block requests for old browsers that do not support `async`
+   *
+   * @default false
+   */
+  compability?: boolean;
   /**
    * Plugin can be disabled by setting this to `false` for Ex: `enabled: !!GDPR_Cookie`
    *
@@ -53,6 +59,7 @@ const config: VueGtmUseOptions = {
   queryParams: undefined,
   loadScript: true,
   defer: false,
+  compability: false,
 };
 
 export default config;

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,7 +22,7 @@ export interface VueGtmUseOptions {
    *
    * @default false
    */
-  compability?: boolean;
+  compatibility?: boolean;
   /**
    * Plugin can be disabled by setting this to `false` for Ex: `enabled: !!GDPR_Cookie`
    *
@@ -59,7 +59,7 @@ const config: VueGtmUseOptions = {
   queryParams: undefined,
   loadScript: true,
   defer: false,
-  compability: false,
+  compatibility: false,
 };
 
 export default config;

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ function install(Vue: App, initConf: VueGtmUseOptions = { id: "" }): void {
   pluginConfig.enabled = initConf.enabled;
   pluginConfig.loadScript = initConf.loadScript;
   pluginConfig.defer = initConf.defer;
+  pluginConfig.compability = initConf.compability;
 
   // Handle vue-router if defined
   if (initConf.vueRouter) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ function install(Vue: App, initConf: VueGtmUseOptions = { id: "" }): void {
   pluginConfig.enabled = initConf.enabled;
   pluginConfig.loadScript = initConf.loadScript;
   pluginConfig.defer = initConf.defer;
-  pluginConfig.compability = initConf.compability;
+  pluginConfig.compatibility = initConf.compatibility;
 
   // Handle vue-router if defined
   if (initConf.vueRouter) {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -39,14 +39,14 @@ export default class VueGtmPlugin {
         this.id.forEach((id) => {
           loadScript(id, {
             defer: pluginConfig.defer,
-            compability: pluginConfig.compability,
+            compatibility: pluginConfig.compatibility,
             queryParams: pluginConfig.queryParams,
           });
         });
       } else {
         loadScript(this.id, {
           defer: pluginConfig.defer,
-          compability: pluginConfig.compability,
+          compatibility: pluginConfig.compatibility,
           queryParams: pluginConfig.queryParams,
         });
       }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -39,12 +39,14 @@ export default class VueGtmPlugin {
         this.id.forEach((id) => {
           loadScript(id, {
             defer: pluginConfig.defer,
+            compability: pluginConfig.compability,
             queryParams: pluginConfig.queryParams,
           });
         });
       } else {
         loadScript(this.id, {
           defer: pluginConfig.defer,
+          compability: pluginConfig.compability,
           queryParams: pluginConfig.queryParams,
         });
       }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,7 +18,7 @@ export function logDebug(message: string, args: Record<string, any>): void {
  * @param id GTM ID
  * @param params query params object
  */
-export function loadScript(id: string, config: Pick<VueGtmUseOptions, "defer" | "queryParams"> = {}): void {
+export function loadScript(id: string, config: Pick<VueGtmUseOptions, "defer" | "queryParams" | "compability"> = {}): void {
   const win = window,
     doc = document,
     script = doc.createElement("script"),
@@ -35,8 +35,8 @@ export function loadScript(id: string, config: Pick<VueGtmUseOptions, "defer" | 
     return;
   }
 
-  script.async = true;
-  script.defer = config.defer || false;
+  script.async = !config.defer;
+  script.defer = Boolean(config.defer || config.compability);
 
   const queryString = new URLSearchParams({
     id,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,7 +18,7 @@ export function logDebug(message: string, args: Record<string, any>): void {
  * @param id GTM ID
  * @param params query params object
  */
-export function loadScript(id: string, config: Pick<VueGtmUseOptions, "defer" | "queryParams" | "compability"> = {}): void {
+export function loadScript(id: string, config: Pick<VueGtmUseOptions, "defer" | "compatibility" | "queryParams"> = {}): void {
   const win = window,
     doc = document,
     script = doc.createElement("script"),
@@ -36,7 +36,7 @@ export function loadScript(id: string, config: Pick<VueGtmUseOptions, "defer" | 
   }
 
   script.async = !config.defer;
-  script.defer = Boolean(config.defer || config.compability);
+  script.defer = Boolean(config.defer || config.compatibility);
 
   const queryString = new URLSearchParams({
     id,


### PR DESCRIPTION
Hi, I just wanted to use the defer option in our project but noticed that it does not change the script execution behavoir. Then i saw that the script gets both async and defer attributes set. There should only be one at a time if you do not want to have old browser compability for parallel script loading. Please check this out: https://html.spec.whatwg.org/multipage/scripting.html#attr-script-defer

 