### PR TITLE
Allow overriding event name when syncing vue-gtm with vue-router

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -82,10 +82,10 @@ export default class VueGtmPlugin {
     if (inBrowser && pluginConfig.enabled) {
       let dataLayer = (window.dataLayer = window.dataLayer || []);
       dataLayer.push({
-        ...additionalEventData,
         event: "content-view",
         "content-name": path,
         "content-view-name": screenName,
+        ...additionalEventData,
       });
     }
   }


### PR DESCRIPTION
Move on extra information to the bottom of dataLayer.push call in order to allow overriding event name and other properties.