### PR TITLE
Multiple GTM-container support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ const app = createApp(App);
 app.use(router);
 
 app.use(createGtm({
-  id: 'GTM-xxxxxx' or ['GTM-xxxxxx', 'GTM-yyyyyy'], // Your GTM single container ID or array of container ids ['GTM-xxxxxx', 'GTM-yyyyyy']
+  id: 'GTM-xxxxxx' or ['GTM-xxxxxx', 'GTM-yyyyyy'] or array of objects [{id: 'GTM-xxxxxx', queryPararms: { gtm_auth: 'abc123', gtm_preview: 'env-4', gtm_cookies_win: 'x'}}, {id: 'GTM-yyyyyy', queryParams: {gtm_auth: 'abc234', gtm_preview: 'env-5', gtm_cookies_win: 'x'}}], // Your GTM single container ID or array of container ids ['GTM-xxxxxx', 'GTM-yyyyyy']
   queryParams: { // Add url query string when load gtm.js with GTM ID (optional)
     gtm_auth:'AB7cDEf3GHIjkl-MnOP8qr',
     gtm_preview:'env-4',
@@ -91,7 +91,7 @@ import VueRouter from 'vue-router';
 const router = new VueRouter({ routes, mode, linkActiveClass });
 
 Vue.use(VueGtm, {
-  id: 'GTM-xxxxxx' or ['GTM-xxxxxx', 'GTM-yyyyyy'], // Your GTM single container ID or array of container ids ['GTM-xxxxxx', 'GTM-yyyyyy']
+  id: 'GTM-xxxxxx' or ['GTM-xxxxxx', 'GTM-yyyyyy'] or array of objects [{id: 'GTM-xxxxxx', queryPararms: { gtm_auth: 'abc123', gtm_preview: 'env-4', gtm_cookies_win: 'x'}}, {id: 'GTM-yyyyyy', queryParams: {gtm_auth: 'abc234', gtm_preview: 'env-5', gtm_cookies_win: 'x'}}], // Your GTM single container ID or array of container ids ['GTM-xxxxxx', 'GTM-yyyyyy']
   queryParams: { // Add url query string when load gtm.js with GTM ID (optional)
     gtm_auth:'AB7cDEf3GHIjkl-MnOP8qr',
     gtm_preview:'env-4',

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,11 +4,16 @@ export interface VueGtmQueryParams {
   gtm_cookies_win: string;
 }
 
+export interface VueGtmContainer {
+  id: string;
+  queryParams?: VueGtmQueryParams;
+}
+
 export interface VueGtmUseOptions {
   /**
-   * Your GTM single container ID or array of container ids ['GTM-xxxxxx', 'GTM-yyyyyy']
+   * Your GTM single container ID, array of container ids ['GTM-xxxxxx', 'GTM-yyyyyy'], or array of objects [{id: 'GTM-xxxxxx', queryPararms: { gtm_auth: 'abc123', gtm_preview: 'env-4', gtm_cookies_win: 'x'}}, {id: 'GTM-yyyyyy', queryParams: {gtm_auth: 'abc234', gtm_preview: 'env-5', gtm_cookies_win: 'x'}}].
    */
-  id: string | string[];
+  id: string | string[] | VueGtmContainer[];
   /**
    * Add url query string when load gtm.js with GTM ID
    */

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,4 +1,4 @@
-import pluginConfig from "./config";
+import pluginConfig, { VueGtmContainer } from "./config";
 import { hasScript, loadScript, logDebug } from "./utils";
 
 const inBrowser: boolean = typeof window !== "undefined";
@@ -17,7 +17,7 @@ export interface VueGtmTrackEventParams {
  * Plugin main class
  */
 export default class VueGtmPlugin {
-  constructor(public readonly id: string | string[]) {}
+  constructor(public readonly id: string | string[] | VueGtmContainer[]) {}
 
   /**
    * Check if plugin is enabled
@@ -36,12 +36,20 @@ export default class VueGtmPlugin {
 
     if (inBrowser && !!val && !hasScript() && pluginConfig.loadScript) {
       if (Array.isArray(this.id)) {
-        this.id.forEach((id) => {
-          loadScript(id, {
-            defer: pluginConfig.defer,
-            compatibility: pluginConfig.compatibility,
-            queryParams: pluginConfig.queryParams,
-          });
+        this.id.forEach((id: string | VueGtmContainer) => {
+          if (typeof id === "string") {
+            loadScript(id, {
+              defer: pluginConfig.defer,
+              compatibility: pluginConfig.compatibility,
+              queryParams: pluginConfig.queryParams,
+            });
+          } else {
+            loadScript(id.id, {
+              defer: pluginConfig.defer,
+              compatibility: pluginConfig.compatibility,
+              queryParams: id.queryParams,
+            });
+          }
         });
       } else {
         loadScript(this.id, {

--- a/tests/vue-use.test.ts
+++ b/tests/vue-use.test.ts
@@ -36,6 +36,41 @@ describe("Vue.use", () => {
     expect(document.scripts.item(0)?.src).toBe("https://www.googletagmanager.com/gtm.js?id=GTM-DEMO");
   });
 
+  test("should append multiple google tag manager scripts to DOM", () => {
+    const appDiv: HTMLDivElement = document.createElement("div");
+    appDiv.id = "app";
+    document.body.appendChild(appDiv);
+
+    const app: App<Element> = createApp(
+      defineComponent({
+        name: "App",
+        render() {
+          return null;
+        },
+      })
+    );
+
+    expect(window["dataLayer"]).toBeUndefined();
+    expect(document.scripts.length).toBe(0);
+
+    app.use(
+      createGtm({
+        id: [
+          { id: "GTM-DEMO", queryParams: { gtm_auth: "abc123", gtm_preview: "env-1", gtm_cookies_win: "x" } },
+          { id: "GTM-DEMO2", queryParams: { gtm_auth: "abc234", gtm_preview: "env-2", gtm_cookies_win: "x" } },
+        ],
+      })
+    );
+
+    app.mount("#app");
+
+    expect(window["dataLayer"]).toBeDefined();
+    expect(document.scripts.length).toBe(2);
+    expect(document.scripts.item(0)).toBeDefined();
+    expect(document.scripts.item(0)?.src).toBe("https://www.googletagmanager.com/gtm.js?id=GTM-DEMO");
+    expect(document.scripts.item(1)?.src).toBe("https://www.googletagmanager.com/gtm.js?id=GTM-DEMO2");
+  });
+
   test("should not append google tag manager script to DOM if disabled", () => {
     const appDiv: HTMLDivElement = document.createElement("div");
     appDiv.id = "app";


### PR DESCRIPTION
When you have multiple container ID's, you may need different query parameters for each.  This allows you to do so in a backwards-compatible way.

Another way I thought about doing it was adding another config key called `containers` so as not to muddy up or confuse what the `id` key is.