### PR TITLE
Pass queryParams correctly to script

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,7 @@ function install(Vue: App, initConf: VueGtmUseOptions = { id: "" }): void {
             ...initConf,
           };
 
-          if (id.queryParams !== null) {
+          if (id.queryParams != null) {
             newConf.queryParams = {
               ...newConf.queryParams,
               ...id.queryParams,

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,11 +56,18 @@ function install(Vue: App, initConf: VueGtmUseOptions = { id: "" }): void {
         if (typeof id === "string") {
           loadScript(id, initConf);
         } else {
-          initConf = {
+          const newConf: VueGtmUseOptions = {
             ...initConf,
-            ...(id.queryParams ?? {}),
           };
-          loadScript(id.id, initConf);
+
+          if (id.queryParams !== null) {
+            newConf.queryParams = {
+              ...newConf.queryParams,
+              ...id.queryParams,
+            } as VueGtmQueryParams;
+          }
+
+          loadScript(id.id, newConf);
         }
       });
     } else {

--- a/tests/vue-use.test.ts
+++ b/tests/vue-use.test.ts
@@ -67,8 +67,12 @@ describe("Vue.use", () => {
     expect(window["dataLayer"]).toBeDefined();
     expect(document.scripts.length).toBe(2);
     expect(document.scripts.item(0)).toBeDefined();
-    expect(document.scripts.item(0)?.src).toBe("https://www.googletagmanager.com/gtm.js?id=GTM-DEMO");
-    expect(document.scripts.item(1)?.src).toBe("https://www.googletagmanager.com/gtm.js?id=GTM-DEMO2");
+    expect(document.scripts.item(0)?.src).toBe(
+      "https://www.googletagmanager.com/gtm.js?id=GTM-DEMO&gtm_auth=abc123&gtm_preview=env-1&gtm_cookies_win=x"
+    );
+    expect(document.scripts.item(1)?.src).toBe(
+      "https://www.googletagmanager.com/gtm.js?id=GTM-DEMO2&gtm_auth=abc234&gtm_preview=env-2&gtm_cookies_win=x"
+    );
   });
 
   test("should not append google tag manager script to DOM if disabled", () => {


### PR DESCRIPTION
Just noticed my query params from the new container object are not getting attached to the script query params.  This fixes that.