### PR TITLE
Update title for disable debug mode section

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Enable debug mode
 this.$gtm.debug(true);
 ```
 
-Disable plugin
+Disable debug mode
 
 ```js
 this.$gtm.debug(false);


### PR DESCRIPTION
This section is referring to disabling the plugin when it should be for disabling debug mode. It was probably an accidental copy and paste from the section above.