### PR TITLE
Fix #119: make event optional in DataLayerObject

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -7,7 +7,7 @@ import { hasScript, loadScript } from "./utils";
  * @see [developers.google.com/tag-manager/devguide](https://developers.google.com/tag-manager/devguide)
  */
 export interface DataLayerObject extends Record<string, any> {
-  event: string;
+  event?: string;
 }
 
 declare global {


### PR DESCRIPTION
This fixes #119 for me; make `event` optional in `DataLayerObject`. I'm using Vue 2 so I made this patch off the vue-2 branch; hope that's OK.